### PR TITLE
Disabling soft limits on chemRIXS ATM and changing OUT position

### DIFF
--- a/plc-kfe-rix-motion/_Config/NC/Axes/Axis 15 TM2K2-MMS-Y.xti
+++ b/plc-kfe-rix-motion/_Config/NC/Axes/Axis 15 TM2K2-MMS-Y.xti
@@ -1348,7 +1348,7 @@ External Setpoint Generation:
 		</DataType>
 	</DataTypes>
 	<Axis Id="15" CreateSymbols="true" AxisType="1" AxisFolder="TM2K2-K2B">
-		<Name>Axis 15 TM2K2-MMS-Y</Name>
+		<Name>__FILENAME__</Name>
 		<AxisPara>
 			<Dynamic AccelerationMaximum="200" DecelerationMaximum="200" Acceleration="10" Deceleration="10" Jerk="500" DelayTime="0.004"/>
 			<Velo Maximum="20"/>
@@ -1357,8 +1357,8 @@ External Setpoint Generation:
 		</AxisPara>
 		<Encoder Name="Enc" EncType="29">
 			<EncPara ScaleFactorNumerator="5e-05" Offset="-214682" MaxCount="#xffffffff" ReferenceSystem="1">
-				<SoftEndMinControl Enable="true" Range="-100"/>
-				<SoftEndMaxControl Enable="true" Range="-16"/>
+				<SoftEndMinControl Range="-100"/>
+				<SoftEndMaxControl Range="-16"/>
 				<Inc RefSoftSyncMask="#x0000ffff"/>
 			</EncPara>
 			<Vars VarGrpType="1">

--- a/plc-kfe-rix-motion/kfe_rix_motion/POUs/PRG_TM2K2_ATM.TcPOU
+++ b/plc-kfe-rix-motion/kfe_rix_motion/POUs/PRG_TM2K2_ATM.TcPOU
@@ -18,7 +18,7 @@ END_VAR
       <ST><![CDATA[fbTM2K2.nTransitionAssertionID := 16#5220;
 fbTM2K2.nUnknownAssertionID := 16#5229;
 
-fbTM2K2.stOut.fPosition := -15;
+fbTM2K2.stOut.fPosition := 5.3;  //"-15" Changing OUT setpoint as -15 doesn't seem to be OUT position;
 fbTM2K2.stOut.bUseRawCounts := FALSE;
 fbTM2K2.stOut.nRequestAssertionID := 16#5221;
 fbTM2K2.stOut.stBeamParams := PMPS_GVL.cstFullBeam;


### PR DESCRIPTION
* Disabling soft limits on chemRIXS ATM for testing target setpoints during beamtime
* Changing OUT position by visually checking OUT on ATM