### PR TITLE
BUG: remember to include FB_MotionStage for this motor

### DIFF
--- a/plc-kfe-rix-motion/kfe_rix_motion/POUs/PRG_AT1K2_SOLID.TcPOU
+++ b/plc-kfe-rix-motion/kfe_rix_motion/POUs/PRG_AT1K2_SOLID.TcPOU
@@ -46,6 +46,7 @@ VAR
     // Special case: inspection mirror
     {attribute 'pytmc' := 'pv: AT1K2:L2SI:MMS:03'}
     fbStage3: FB_PositionState1D_InOut;
+    fbMotionStage3: FB_MotionStage;
     stMirrorOut: ST_PositionState;
     stMirrorIn: ST_PositionState;
     // Consider transmission=1 if out, transmission=0 if in
@@ -190,6 +191,7 @@ fbStage3(
     stOut:=stMirrorOut,
     stIn:=stMirrorIn,
 );
+fbMotionStage3(stMotionStage:=Main.M27);
 
 IF fbStage3.eStateGet = E_EpicsInOut.OUT THEN
     fMirrorTrans := 1.0;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Blade 3 on AT1K2 isn't working right now, this probably fixes it.
When refactoring this, the state FBs for the filters did not need an extra FB_MotionStage, since this is included inside their state FBs, so I didn't notice that I had forgotten to include it for the mirror axis, which doesn't have this included because I switched to using the standard FB from lcls-twincat-motion.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://jira.slac.stanford.edu/browse/ECS-4484

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Will test tomorrow with Jyoti and Kayla's permission
I'm hesitant to push for testing today because the PLC doesn't even let me log in right now

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->


## Screenshots (if appropriate):

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive comments
- [ ] Test suite passes locally
- [ ] Libraries are set to fixed versions and not ``Always Newest``
- [ ] Code committed with ``pre-commit`` (alternatively ``pre-commit run --all-files``)
